### PR TITLE
fix missing openssh - sshd works again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ADD initXETemp.ora /
 
 RUN apt-get update && \
     apt-get install -y libaio1 net-tools bc && \
+    apt-get install -y openssh-server && \
+    mkdir -p /var/run/sshd && \
     apt-get autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -33,6 +35,7 @@ RUN echo 'export ORACLE_SID=XE' >> /etc/bash.bashrc
 
 VOLUME /usr/lib/oracle/xe/oradata/XE
 
+EXPOSE 22
 EXPOSE 1521
 EXPOSE 8080
 


### PR DESCRIPTION
This fixes the error people were complaining about where sshd command was not found.

For security reasons, no default password is set for root or oracle user, if people want to use the sshd, they'll have to enter the container with docker exec -it  and then set the password before using sshd.
